### PR TITLE
Fix: TF path module

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 locals {
-  archive_path = "${path.module}/build/src"
+  archive_path = "./build/src"
 
   cloudwatch = {
     codebuild_log_group_prefix = "/aws/codebuild"

--- a/locals.tf
+++ b/locals.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 locals {
-  archive_path = "./build/src"
+  archive_path = "build/src"
 
   cloudwatch = {
     codebuild_log_group_prefix = "/aws/codebuild"


### PR DESCRIPTION
## Related Issue
Issue #7 

## Context
When running the module, CodeBuild encounters the following error:
![image](https://github.com/user-attachments/assets/bbbf74eb-7687-40b1-b595-48c76da5bc32)

That is caused by the usage of the `"path.module"` terraform operation in the ["archive_path" local variable](https://github.com/aws-ia/terraform-aws-sce-tf-community/blob/main/locals.tf#L5C3-L5C15)

Terraform documentation advises against its usage for write operation, as can be seen [here](https://developer.hashicorp.com/terraform/language/expressions/references#filesystem-and-workspace-info).

## Proposed fix

By removing `${path.module}` from the local variable, the objects are written to the expected S3 key.

## Evidences

Local plan:
![image](https://github.com/user-attachments/assets/b713437c-5b79-44c5-80a1-dc0718937f1c)

Remote plan:
> Note: the resources were already provisioned with the wrong path

![image](https://github.com/user-attachments/assets/3352aee4-4bf5-4738-b4b4-a82bbcee566c)

